### PR TITLE
Avoid duplicating images

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function collectImages(css, opts) {
     }
   });
 
-  return images;
+  return lodash.uniqWith(images, lodash.isEqual);
 }
 
 function applyGroupBy(images, opts) {

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ function runSpriteSmith(images, opts) {
       })
       .map(function (images, temp) {
         var config = lodash.merge({}, opts, {
-          src: lodash.pluck(images, 'path'),
+          src: lodash.map(images, 'path'),
         });
         var ratio;
 


### PR DESCRIPTION
I got an issue which images have been duplicated in the sprites output. It may happen due to different selectors are using the same image, or using with nested scss rules so `walkRules` will collect images multiple times. Eg.

```scss
.container {
   .logo {
      background: url('foo.png');
  }
  
  .blah {}
}
```