### PR TITLE
fix broken dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var lodash = require('lodash');
 var url = require('url');
 var path = require('path');
 var async = require('async');
-var spritesmith = require('spritesmith');
+var spritesmith = require('spritesmith').run;
 var mkdirp = require('mkdirp');
 var fs = require('fs');
 var md5 = require('md5');
@@ -225,8 +225,8 @@ function runSpriteSmith(images, opts) {
         if (areAllRetina(images)) {
           ratio = lodash
             .chain(images)
-            .flatten('ratio')
-            .unique()
+            .flatMap('ratio')
+            .uniq()
             .value();
 
           if (ratio.length === 1) {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "homepage": "https://github.com/glebmachine/postcss-easysprites",
   "dependencies": {
     "async": "1.5.0",
-    "gulp-postcss": "6.0.1",
-    "gulp-print": "2.0.1",
     "gulp-util": "3.0.7",
     "lodash": "4.13.1",
     "md5": "2.0.0",
@@ -29,7 +27,6 @@
     "spritesmith": "3.1.0"
   },
   "devDependencies": {
-    "ava": "0.15.2",
     "chai": "3.4.1",
     "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
@@ -43,10 +40,10 @@
     "gulp-jshint": "2.0.0",
     "gulp-mocha": "2.2.0",
     "gulp-rename": "1.2.2",
+    "gulp-postcss": "6.0.1",
     "jscs": "3.0.4",
     "jshint": "2.8.0",
-    "jshint-stylish": "2.1.0",
-    "tape": "4.2.2"
+    "jshint-stylish": "2.1.0"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
because of the lodash v3 -> v4 and spritesmith v1.5.0 -> v3.x upgrade, postcss-easysprites did not output any files anymore and just kept silent.

this pr fixes all of that and cleans up some npm dependencies that are not even used.