### PR TITLE
feat: added outputStylesheetPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The plugin supports both relative and absolute paths on input file, but can curr
 | `padding` | The amount of space in pixels to put around images in the sprite. _**Note:**_ This value will be scaled proportionally for retina images. | `20` |
 | `outputDimensions` | Whether to also output the pixel `height` and `width` of the image. | `false` |
 | `algorithm` | The [layout algorithm](https://github.com/twolfson/layout) spritesmith should use. | `binary-tree` |
+| `outputStylesheetPath` | Optional. Path of the final CSS file. If defined, sprite urls are relative to this path. | `undefined` |
 
 ## Input example
 

--- a/lib/plugin-options.js
+++ b/lib/plugin-options.js
@@ -52,6 +52,10 @@ const pluginOptions = {
       customOptions.spritePath || ''
     );
 
+    this.opts.outputStylesheetPath = customOptions.outputStylesheetPath
+      ? path.resolve(process.cwd(), customOptions.outputStylesheetPath)
+      : undefined;
+
     return this.opts;
   },
 

--- a/lib/plugin-options.js
+++ b/lib/plugin-options.js
@@ -30,7 +30,10 @@ const pluginOptions = {
 
     // If custom options have not been defined by the user, add reasonable
     // default ones.
-    this.opts.padding = customOptions.padding || DEFAULT_PADDING;
+    this.opts.padding =
+      customOptions.padding === undefined
+        ? DEFAULT_PADDING
+        : customOptions.padding;
 
     this.opts.algorithm =
       customOptions.algorithm && isValidSpriteLayout(customOptions.algorithm)

--- a/lib/update-references.js
+++ b/lib/update-references.js
@@ -114,7 +114,10 @@ function updateReferences(images, sprites, css) {
 
     // Generate the correct reference to the sprite.
     image.spriteRef = path
-      .relative(image.stylesheetPath, image.spritePath)
+      .relative(
+        opts.outputStylesheetPath || image.stylesheetPath,
+        image.spritePath
+      )
       .split(path.sep)
       .join('/');
 


### PR DESCRIPTION
In my particular use case, I was using rollup to bundle many individual CSS files from various subdirectories under a "src" directory into a single file in a "dist" output directory. 

However, since image.stylesheetPath was pointing to the source directory and image.spritePath was pointing to the destination directory, the generated image.spriteRef relative path in update-references.js was incorrect.

By adding this optional outputStylesheetPath option, it allows us to override that behavior so that the generated sprite url in the stylesheet is relative to the generated stylesheet in the output directory.
